### PR TITLE
Refactor Game into subsystems and add EntityManager

### DIFF
--- a/bonus.cpp
+++ b/bonus.cpp
@@ -13,12 +13,12 @@ Bonus::Bonus(BonusType type, sf::Vector2f position) {
 	}
 }
 void Bonus::update() {sprite.move(0.f, 10.f);}
-void Bonus::draw(sf::RenderWindow& window) { window.draw(sprite); }
-size_t Bonus::getWidth() { return sprite.getLocalBounds().width; }
-size_t Bonus::getHeight() { return sprite.getLocalBounds().height; }
-sf::FloatRect Bonus::getHitBox() { return sprite.getGlobalBounds(); }
-sf::Vector2f Bonus::getPosition() { return sprite.getPosition(); }
-bool Bonus::getDel() { return del; }
+void Bonus::draw(sf::RenderWindow& window) const { window.draw(sprite); }
+size_t Bonus::getWidth() const { return sprite.getLocalBounds().width; }
+size_t Bonus::getHeight() const { return sprite.getLocalBounds().height; }
+sf::FloatRect Bonus::getHitBox() const { return sprite.getGlobalBounds(); }
+sf::Vector2f Bonus::getPosition() const { return sprite.getPosition(); }
+bool Bonus::getDel() const { return del; }
 void Bonus::setDel(bool x) { del = x; }
 
 void Bonus::action(Player *player) const

--- a/bonus.h
+++ b/bonus.h
@@ -8,15 +8,15 @@ public:
 	enum BonusType {HP, SHIELD, FIRE_RATE};
 	Bonus(BonusType type, sf::Vector2f position);
 	void update();
-	void draw(sf::RenderWindow& window);
+	void draw(sf::RenderWindow& window) const;
 
 	void action(Player *player) const;
 
-	size_t getWidth();
-	size_t getHeight();
-	sf::FloatRect getHitBox();
-	sf::Vector2f getPosition();
-	bool getDel();
+	size_t getWidth() const;
+	size_t getHeight() const;
+	sf::FloatRect getHitBox() const;
+	sf::Vector2f getPosition() const;
+	bool getDel() const;
 	void setDel(bool x);
 private:
 	sf::Sprite sprite;

--- a/collision_system.cpp
+++ b/collision_system.cpp
@@ -1,0 +1,70 @@
+#include "collision_system.h"
+#include <algorithm>
+#include <set>
+#include "const.h"
+
+void CollisionSystem::process(Player &player,
+	EntityManager &entities,
+	GameState &game_state) const
+{
+	handle_player_meteor(player, entities, game_state);
+	handle_player_bonus(player, entities);
+	handle_laser_meteor(entities);
+	cleanup_offscreen_entities(entities);
+}
+
+void CollisionSystem::handle_player_meteor(Player &player,
+	EntityManager &entities,
+	GameState &game_state) const
+{
+	for (const auto &meteor : entities.meteors()) {
+		if (player.getHitBox().intersects(meteor->getHitBox())) {
+			player.reduceHp(meteor->getWidth() / 3);
+			meteor->spawn();
+		}
+	}
+
+	if (player.isDead()) {
+		game_state = GameState::GAME_OVER;
+	}
+}
+
+void CollisionSystem::handle_player_bonus(Player &player, EntityManager &entities) const {
+	std::set<std::shared_ptr<Bonus>> active_bonus;
+	copy_if(
+		entities.bonuses().begin(),
+		entities.bonuses().end(),
+		inserter(active_bonus, active_bonus.end()),
+		[&player](const auto &bonus) {
+			return player.getHitBox().intersects(bonus->getHitBox());
+		});
+	entities.bonuses().remove_if([&active_bonus](const auto &bonus) {
+		return active_bonus.count(bonus) > 0;
+	});
+	std::for_each(active_bonus.begin(), active_bonus.end(),
+		[&player](const auto &bonus) { bonus->action(&player); });
+}
+
+void CollisionSystem::handle_laser_meteor(EntityManager &entities) const {
+	for (const auto &laser : entities.lasers()) {
+		for (const auto &meteor : entities.meteors()) {
+			if (laser->getHitBox().intersects(meteor->getHitBox())) {
+				entities.explosions().emplace_back(
+					std::make_shared<Explosion>(meteor->getCenter()));
+
+				meteor->spawn();
+				size_t chance = rand() % 100;
+				if (chance < 10) {
+					auto new_bonus = std::make_shared<Bonus>(
+						static_cast<Bonus::BonusType>(0),
+						meteor->getPosition());
+					entities.bonuses().push_back(new_bonus);
+				}
+			}
+		}
+	}
+}
+
+void CollisionSystem::cleanup_offscreen_entities(EntityManager &entities) const {
+	entities.cleanup_offscreen();
+}

--- a/collision_system.h
+++ b/collision_system.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "entity_manager.h"
+#include "game_state.h"
+#include "player.h"
+
+// Resolves collisions and related side effects between entities.
+class CollisionSystem {
+public:
+	void process(Player &player,
+		EntityManager &entities,
+		GameState &game_state) const;
+
+private:
+	void handle_player_meteor(Player &player,
+		EntityManager &entities,
+		GameState &game_state) const;
+	void handle_player_bonus(Player &player, EntityManager &entities) const;
+	void handle_laser_meteor(EntityManager &entities) const;
+	void cleanup_offscreen_entities(EntityManager &entities) const;
+};

--- a/entity_manager.cpp
+++ b/entity_manager.cpp
@@ -1,0 +1,56 @@
+#include "entity_manager.h"
+#include "const.h"
+
+void EntityManager::spawn_meteors(size_t count) {
+	meteor_sprites.reserve(count);
+	for (size_t i = 0; i < count; i++) {
+		meteor_sprites.emplace_back(std::make_unique<Meteor>());
+	}
+}
+
+void EntityManager::update_all() {
+	for (auto &meteor : meteor_sprites) {
+		meteor->update();
+	}
+	for (auto &laser : laser_sprites) {
+		laser->update();
+	}
+	for (auto &bonus : bonus_sprites) {
+		bonus->update();
+	}
+	for (auto &exp : exp_sprites) {
+		exp->update();
+	}
+}
+
+void EntityManager::draw_all(sf::RenderWindow &window) const {
+	for (const auto &meteor : meteor_sprites) {
+		meteor->draw(window);
+	}
+	for (const auto &laser : laser_sprites) {
+		laser->draw(window);
+	}
+	for (const auto &bonus : bonus_sprites) {
+		bonus->draw(window);
+	}
+	for (const auto &exp : exp_sprites) {
+		exp->draw(window);
+	}
+}
+
+void EntityManager::cleanup_offscreen() {
+	laser_sprites.remove_if([](const auto &laser) { return laser->getPosition().y < 0; });
+	bonus_sprites.remove_if([](const auto &bonus) {
+		return bonus->getPosition().y > WINDOW_HEIGHT; });
+	exp_sprites.remove_if([](const auto &exp) { return exp->getDel(); });
+}
+
+std::vector<std::unique_ptr<Meteor>> &EntityManager::meteors() { return meteor_sprites; }
+std::list<std::unique_ptr<Laser>> &EntityManager::lasers() { return laser_sprites; }
+std::list<std::shared_ptr<Bonus>> &EntityManager::bonuses() { return bonus_sprites; }
+std::list<std::shared_ptr<Explosion>> &EntityManager::explosions() { return exp_sprites; }
+
+const std::vector<std::unique_ptr<Meteor>> &EntityManager::meteors() const { return meteor_sprites; }
+const std::list<std::unique_ptr<Laser>> &EntityManager::lasers() const { return laser_sprites; }
+const std::list<std::shared_ptr<Bonus>> &EntityManager::bonuses() const { return bonus_sprites; }
+const std::list<std::shared_ptr<Explosion>> &EntityManager::explosions() const { return exp_sprites; }

--- a/entity_manager.h
+++ b/entity_manager.h
@@ -1,0 +1,34 @@
+#pragma once
+#include <list>
+#include <memory>
+#include <vector>
+#include "SFML/Graphics.hpp"
+#include "bonus.h"
+#include "explosion.h"
+#include "laser.h"
+#include "meteor.h"
+
+// Stores and manages all game entities except the player.
+class EntityManager {
+public:
+	void spawn_meteors(size_t count);
+	void update_all();
+	void draw_all(sf::RenderWindow &window) const;
+	void cleanup_offscreen();
+
+	std::vector<std::unique_ptr<Meteor>> &meteors();
+	std::list<std::unique_ptr<Laser>> &lasers();
+	std::list<std::shared_ptr<Bonus>> &bonuses();
+	std::list<std::shared_ptr<Explosion>> &explosions();
+
+	const std::vector<std::unique_ptr<Meteor>> &meteors() const;
+	const std::list<std::unique_ptr<Laser>> &lasers() const;
+	const std::list<std::shared_ptr<Bonus>> &bonuses() const;
+	const std::list<std::shared_ptr<Explosion>> &explosions() const;
+
+private:
+	std::vector<std::unique_ptr<Meteor>> meteor_sprites;
+	std::list<std::unique_ptr<Laser>> laser_sprites;
+	std::list<std::shared_ptr<Bonus>> bonus_sprites;
+	std::list<std::shared_ptr<Explosion>> exp_sprites;
+};

--- a/explosion.cpp
+++ b/explosion.cpp
@@ -34,8 +34,8 @@ void Explosion::update() {
 		}
 	}
 }
-void Explosion::draw(sf::RenderWindow& window) { window.draw(sprite); }
-bool Explosion::getDel() { return del; }
+void Explosion::draw(sf::RenderWindow& window) const { window.draw(sprite); }
+bool Explosion::getDel() const { return del; }
 void Explosion::setDel(bool x) { del = x; }
-size_t Explosion::getWidth() { return sprite.getLocalBounds().width; }
-size_t Explosion::getHeight() { return sprite.getLocalBounds().height; }
+size_t Explosion::getWidth() const { return sprite.getLocalBounds().width; }
+size_t Explosion::getHeight() const { return sprite.getLocalBounds().height; }

--- a/explosion.h
+++ b/explosion.h
@@ -13,13 +13,13 @@ private:
 	sf::Vector2f position;
 public:
 	Explosion(const sf::Vector2f &position);
-	void draw(sf::RenderWindow& window);
+	void draw(sf::RenderWindow& window) const;
 	void update();
-	size_t getWidth();
-	size_t getHeight();
+	size_t getWidth() const;
+	size_t getHeight() const;
 	//sf::FloatRect getHitBox();
 	//sf::Vector2f getPosition();
-	bool getDel();
+	bool getDel() const;
 	void setDel(bool x);
 };
 

--- a/game.cpp
+++ b/game.cpp
@@ -1,7 +1,4 @@
 #include "game.h"
-#include <algorithm>
-#include <set>
-
 Game::Game() :
 	window(	sf::VideoMode(
 				static_cast<size_t> (WINDOW_WIDTH), 
@@ -15,10 +12,7 @@ Game::Game() :
 	hp_text(500, 5, 24, sf::Color::Yellow)
 {
 	window.setFramerateLimit(60);
-	meteor_sprites.reserve(METEORS_QTY);
-	for (size_t i = 0; i < METEORS_QTY; i++) {
-		meteor_sprites.emplace_back(std::make_unique<Meteor>());
-	}
+	entities.spawn_meteors(METEORS_QTY);
 
 }
 void Game::play() {
@@ -29,118 +23,11 @@ void Game::play() {
 	}
 }
 void Game::check_events() {
-	sf::Event event;
-	while (window.pollEvent(event)) {
-		if (event.type == sf::Event::Closed) window.close();
-		else 
-			if (event.type == sf::Event::MouseButtonPressed &&
-				event.mouseButton.button == sf::Mouse::Left)
-			{
-				sf::Time elapsed = clock.getElapsedTime();
-				if (elapsed.asMilliseconds() > 250) {
-					laser_sprites.emplace_back(std::make_unique<Laser>(
-						player.getPosition().x + player.getWidth() / 2 - 5,
-						player.getPosition().y));
-					clock.restart();
-				}
-			}
-			
-	}
+	input_handler.handle_events(window, player, entities.lasers(), clock);
 }
 void Game::update() {
-	switch (game_state) {
-	case PLAY:
-		player.update();
-		for (auto &meteor : meteor_sprites) {
-			meteor->update();
-		}
-		for (auto &laser : laser_sprites) {
-			laser->update();
-		}
-		for (auto &bonus : bonus_sprites) {
-			bonus->update();
-		}
-		for (auto &exp : exp_sprites) {
-			exp->update();
-		}
-		check_collisions();
-		hp_text.update(std::to_string(static_cast<int>(player.getHp())));
-		break;
-	case GAME_OVER:
-		break;
-	}
+	update_system.update(game_state, player, entities, collision_system, hp_text);
 }
 void Game::draw() {
-
-	window.clear();
-	switch (game_state) {
-
-	case PLAY:
-		for (const auto &meteor : meteor_sprites) {
-			meteor->draw(window);
-		}
-		for (const auto &laser : laser_sprites) {
-			laser->draw(window);
-		}
-		for (const auto &bonus : bonus_sprites) {
-			bonus->draw(window);
-		}
-		for (const auto &exp : exp_sprites) {
-			exp->draw(window);
-		}
-		player.draw(window);
-		hp_text.draw(window);
-		break;
-	case GAME_OVER:
-		window.draw(game_over.getSprite());
-	}
-	window.display();
-}
-void Game::check_collisions() {
-	//����� � ���������
-	for (const auto &meteor : meteor_sprites) {
-		if (player.getHitBox().intersects(meteor->getHitBox()))
-		{
-			player.reduceHp(meteor->getWidth()/3);
-			meteor->spawn();
-		}
-	}
-	//������� �����, �������������� � �������
-	std::set<std::shared_ptr<Bonus>> active_bonus;
-	copy_if(
-		bonus_sprites.begin(),
-		bonus_sprites.end(),
-		inserter(active_bonus, active_bonus.end()),
-		[this](const auto &bonus) {return player.getHitBox().intersects(bonus->getHitBox()); }
-	);
-	bonus_sprites.remove_if([&active_bonus](const auto &bonus) { return active_bonus.count(bonus) > 0; });
-	std::for_each(active_bonus.begin(), active_bonus.end(), [this](const auto &bonus){ bonus->action(&player); });
-	//����� ����
-	if (player.isDead()) game_state = GAME_OVER;
-	//�������� ���� �� ����� ������
-	laser_sprites.remove_if([](const auto &laser) { return laser->getPosition().y < 0; });
-	//�������� ������� �� ����� ������
-	bonus_sprites.remove_if([](const auto &bonus) {
-		return bonus->getPosition().y > WINDOW_HEIGHT; });
-	//���� � ���������
-	for (const auto &laser : laser_sprites) {
-		for (const auto &meteor : meteor_sprites) {
-			if (laser->getHitBox().intersects(meteor->getHitBox()))
-			{
-				exp_sprites.emplace_back(std::make_shared<Explosion>(meteor->getCenter()));
-
-				meteor->spawn();
-				//c ������ 10% �� ������� �������� �����
-				size_t chance = rand() % 100;
-				if (chance < 10) {
-					//������������� ��������� ����� ��� ���� ������
-					auto new_bonus = std::make_shared<Bonus>(static_cast<Bonus::BonusType>(0),
-						meteor->getPosition());
-					bonus_sprites.push_back(new_bonus);
-				}
-			}
-		}
-	}
-	//������� ���������� �� �������� ������
-	exp_sprites.remove_if([](const auto &exp) {return exp->getDel(); });
+	render_system.draw(game_state, window, player, entities, hp_text, game_over);
 }

--- a/game.h
+++ b/game.h
@@ -1,37 +1,36 @@
 #pragma once
-#include <memory>
 #include "const.h"
 #include "SFML/Graphics.hpp"
+#include "collision_system.h"
+#include "entity_manager.h"
+#include "game_state.h"
+#include "input_handler.h"
 #include "player.h"
-#include "meteor.h"
-#include <vector>
+#include "render_system.h"
 #include "splash.h"
-#include <list>
-#include "laser.h"
 #include "text.h"
-#include "bonus.h"
-#include "explosion.h"
+#include "update_system.h"
 
+// Orchestrates the high-level game loop and state transitions.
 class Game {
 public:
-	enum GameState {INTRO, PLAY, PAUSE, GAME_OVER};
 	Game();
 	void play();
 private:
 	void check_events();
 	void update();
 	void draw();
-	void check_collisions();
 
 	sf::RenderWindow window;
 	Player player;
-	GameState game_state = PLAY;
+	GameState game_state = GameState::PLAY;
 	Splash game_over;
-	std::vector<std::unique_ptr<Meteor>> meteor_sprites;
-	std::list<std::unique_ptr<Laser>> laser_sprites;
 	TextObj hp_text;
 	sf::Clock clock;
-	std::list<std::shared_ptr<Bonus>> bonus_sprites;
-	std::list<std::shared_ptr<Explosion>> exp_sprites;
+	EntityManager entities;
+	InputHandler input_handler;
+	UpdateSystem update_system;
+	RenderSystem render_system;
+	CollisionSystem collision_system;
 };
 

--- a/game_state.h
+++ b/game_state.h
@@ -1,0 +1,4 @@
+#pragma once
+
+// Represents the high-level game state.
+enum class GameState { INTRO, PLAY, PAUSE, GAME_OVER };

--- a/input_handler.cpp
+++ b/input_handler.cpp
@@ -1,0 +1,23 @@
+#include "input_handler.h"
+
+void InputHandler::handle_events(sf::RenderWindow &window,
+	Player &player,
+	std::list<std::unique_ptr<Laser>> &lasers,
+	sf::Clock &fire_clock) const
+{
+	sf::Event event;
+	while (window.pollEvent(event)) {
+		if (event.type == sf::Event::Closed) {
+			window.close();
+		} else if (event.type == sf::Event::MouseButtonPressed &&
+			event.mouseButton.button == sf::Mouse::Left) {
+			sf::Time elapsed = fire_clock.getElapsedTime();
+			if (elapsed.asMilliseconds() > 250) {
+				lasers.emplace_back(std::make_unique<Laser>(
+					player.getPosition().x + player.getWidth() / 2 - 5,
+					player.getPosition().y));
+				fire_clock.restart();
+			}
+		}
+	}
+}

--- a/input_handler.h
+++ b/input_handler.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <list>
+#include <memory>
+#include "SFML/Graphics.hpp"
+#include "laser.h"
+#include "player.h"
+
+// Handles input events and player shooting behavior.
+class InputHandler {
+public:
+	void handle_events(sf::RenderWindow &window,
+		Player &player,
+		std::list<std::unique_ptr<Laser>> &lasers,
+		sf::Clock &fire_clock) const;
+};

--- a/laser.cpp
+++ b/laser.cpp
@@ -9,8 +9,8 @@ Laser::Laser(float x, float y) {
 void Laser::update() {
 	sprite.move(0.f, -LASER_SPEEDY);
 }
-size_t Laser::getWidth() { return sprite.getLocalBounds().width; }
-size_t Laser::getHeight() { return sprite.getLocalBounds().height; }
-sf::FloatRect Laser::getHitBox() { return sprite.getGlobalBounds(); }
-void Laser::draw(sf::RenderWindow& window) { window.draw(sprite); }
-sf::Vector2f Laser::getPosition() { return sprite.getPosition(); }
+size_t Laser::getWidth() const { return sprite.getLocalBounds().width; }
+size_t Laser::getHeight() const { return sprite.getLocalBounds().height; }
+sf::FloatRect Laser::getHitBox() const { return sprite.getGlobalBounds(); }
+void Laser::draw(sf::RenderWindow& window) const { window.draw(sprite); }
+sf::Vector2f Laser::getPosition() const { return sprite.getPosition(); }

--- a/laser.h
+++ b/laser.h
@@ -7,10 +7,10 @@ private:
 	sf::Texture texture;
 public:
 	Laser(float, float);
-	void draw(sf::RenderWindow& window);
+	void draw(sf::RenderWindow& window) const;
 	void update();
-	size_t getWidth();
-	size_t getHeight();
-	sf::FloatRect getHitBox();
-	sf::Vector2f getPosition();
+	size_t getWidth() const;
+	size_t getHeight() const;
+	sf::FloatRect getHitBox() const;
+	sf::Vector2f getPosition() const;
 };

--- a/meteor.cpp
+++ b/meteor.cpp
@@ -15,7 +15,7 @@ Meteor::Meteor() {
 	sprite.setTexture(texture);
 	spawn();
 }
-void Meteor::draw(sf::RenderWindow& window) {
+void Meteor::draw(sf::RenderWindow& window) const {
 	window.draw(sprite);
 }
 void Meteor::update() {
@@ -28,10 +28,10 @@ void Meteor::update() {
 		spawn();
 	}
 }
-size_t Meteor::getWidth() { return sprite.getLocalBounds().width; }
-size_t Meteor::getHeight() { return sprite.getLocalBounds().height; }
-sf::FloatRect Meteor::getHitBox() { return sprite.getGlobalBounds(); }
-sf::Vector2f Meteor::getPosition() { return sprite.getPosition(); }
+size_t Meteor::getWidth() const { return sprite.getLocalBounds().width; }
+size_t Meteor::getHeight() const { return sprite.getLocalBounds().height; }
+sf::FloatRect Meteor::getHitBox() const { return sprite.getGlobalBounds(); }
+sf::Vector2f Meteor::getPosition() const { return sprite.getPosition(); }
 void Meteor::spawn() {
 	float startx = rand() % (static_cast<size_t>(WINDOW_WIDTH) - getWidth() + 1);
 	float starty = rand() % (static_cast<size_t>(WINDOW_HEIGHT) + 1) - WINDOW_HEIGHT;
@@ -39,7 +39,7 @@ void Meteor::spawn() {
 	speedx = rand() % 5 - 2;
 	speedy = rand() % 8 + 3;
 }
-sf::Vector2f Meteor::getCenter() {
+sf::Vector2f Meteor::getCenter() const {
 	return sf::Vector2f
 	(
 		sprite.getPosition().x + getWidth() / 2.0,

--- a/meteor.h
+++ b/meteor.h
@@ -10,12 +10,12 @@ private:
 	static std::string meteor_file_names[];
 public:
 	Meteor();
-	void draw(sf::RenderWindow& window);
+	void draw(sf::RenderWindow& window) const;
 	void update();
-	size_t getWidth();
-	size_t getHeight();
-	sf::FloatRect getHitBox();
-	sf::Vector2f getPosition();
-	sf::Vector2f getCenter();
+	size_t getWidth() const;
+	size_t getHeight() const;
+	sf::FloatRect getHitBox() const;
+	sf::Vector2f getPosition() const;
+	sf::Vector2f getCenter() const;
 	void spawn();
 };

--- a/player.cpp
+++ b/player.cpp
@@ -6,7 +6,7 @@ Player::Player(float x, float y, std::string texture_file_name){
 	sprite.setTexture(texture);
 	sprite.setPosition(x, y);
 }
-void Player::draw(sf::RenderWindow& window) {
+void Player::draw(sf::RenderWindow& window) const {
 	window.draw(sprite);
 }
 void Player::update() {
@@ -25,10 +25,10 @@ void Player::update() {
 			sprite.move(speedx, 0);
 		}
 }
-size_t Player::getWidth() { return sprite.getLocalBounds().width; }
-size_t Player::getHeight() { return sprite.getLocalBounds().height; }
-sf::FloatRect Player::getHitBox() { return sprite.getGlobalBounds(); }
-sf::Vector2f Player::getPosition() { return sprite.getPosition(); }
+size_t Player::getWidth() const { return sprite.getLocalBounds().width; }
+size_t Player::getHeight() const { return sprite.getLocalBounds().height; }
+sf::FloatRect Player::getHitBox() const { return sprite.getGlobalBounds(); }
+sf::Vector2f Player::getPosition() const { return sprite.getPosition(); }
 void Player::reduceHp(float dmg) {	hp -= dmg; }
-bool Player::isDead() { return hp < 0; }
-float Player::getHp() { return hp; }
+bool Player::isDead() const { return hp < 0; }
+float Player::getHp() const { return hp; }

--- a/player.h
+++ b/player.h
@@ -9,14 +9,14 @@ private:
 	float hp = PLAYER_HP;
 public:
 	Player(float x, float y, std::string texture_file_name);
-	void draw(sf::RenderWindow& window);
+	void draw(sf::RenderWindow& window) const;
 	void update();
-	size_t getWidth();
-	size_t getHeight();
-	sf::FloatRect getHitBox();
-	sf::Vector2f getPosition();
+	size_t getWidth() const;
+	size_t getHeight() const;
+	sf::FloatRect getHitBox() const;
+	sf::Vector2f getPosition() const;
 	void reduceHp(float dmg);
-	bool isDead();
-	float getHp();
+	bool isDead() const;
+	float getHp() const;
 };
 

--- a/render_system.cpp
+++ b/render_system.cpp
@@ -1,0 +1,24 @@
+#include "render_system.h"
+
+void RenderSystem::draw(GameState game_state,
+	sf::RenderWindow &window,
+	const Player &player,
+	const EntityManager &entities,
+	const TextObj &hp_text,
+	const Splash &game_over) const
+{
+	window.clear();
+	switch (game_state) {
+	case GameState::PLAY:
+		entities.draw_all(window);
+		player.draw(window);
+		hp_text.draw(window);
+		break;
+	case GameState::GAME_OVER:
+		window.draw(game_over.getSprite());
+		break;
+	default:
+		break;
+	}
+	window.display();
+}

--- a/render_system.h
+++ b/render_system.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "entity_manager.h"
+#include "game_state.h"
+#include "player.h"
+#include "splash.h"
+#include "text.h"
+
+// Renders entities and UI based on the current game state.
+class RenderSystem {
+public:
+	void draw(GameState game_state,
+		sf::RenderWindow &window,
+		const Player &player,
+		const EntityManager &entities,
+		const TextObj &hp_text,
+		const Splash &game_over) const;
+};

--- a/splash.h
+++ b/splash.h
@@ -11,5 +11,5 @@ public:
 		texture.loadFromFile(IMAGES_FOLDER + "game-over.jpg");
 		sprite.setTexture(texture);
 	}
-	sf::Sprite getSprite() { return sprite; }
+	sf::Sprite getSprite() const { return sprite; }
 };

--- a/text.h
+++ b/text.h
@@ -16,5 +16,5 @@ public:
 	}
 	//sf::Text getText() { return text; }
 	void update(std::string str) { text.setString(str); }
-	void draw(sf::RenderWindow& window) { window.draw(text); }
+	void draw(sf::RenderWindow& window) const { window.draw(text); }
 };

--- a/update_system.cpp
+++ b/update_system.cpp
@@ -1,0 +1,18 @@
+#include "update_system.h"
+#include <string>
+
+void UpdateSystem::update(GameState &game_state,
+	Player &player,
+	EntityManager &entities,
+	CollisionSystem &collisions,
+	TextObj &hp_text) const
+{
+	if (game_state != GameState::PLAY) {
+		return;
+	}
+
+	player.update();
+	entities.update_all();
+	collisions.process(player, entities, game_state);
+	hp_text.update(std::to_string(static_cast<int>(player.getHp())));
+}

--- a/update_system.h
+++ b/update_system.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "collision_system.h"
+#include "entity_manager.h"
+#include "game_state.h"
+#include "player.h"
+#include "text.h"
+
+// Updates player, entities, and UI state each frame.
+class UpdateSystem {
+public:
+	void update(GameState &game_state,
+		Player &player,
+		EntityManager &entities,
+		CollisionSystem &collisions,
+		TextObj &hp_text) const;
+};


### PR DESCRIPTION
### Motivation
- Separate responsibilities of the monolithic `Game` class to improve readability and make the project easier to extend with new entities, bonuses and states.
- Provide a central place to own and manage non-player entities so lifecycle operations (spawn/update/draw/cleanup) are consistent and testable.
- Move collision, input, update and render logic into focused systems so `Game` only coordinates the high-level loop and state transitions.
- Make rendering/state accessor APIs const-correct to enable safer const paths and clearer contracts for systems.

### Description
- Introduced `GameState` (`game_state.h`) and refactored `Game` to be an orchestrator that delegates to systems and holds an `EntityManager` (changed `game.h`/`game.cpp`).
- Added `EntityManager` (`entity_manager.h`/`.cpp`) to own meteors, lasers, bonuses and explosions and provide `spawn_meteors`, `update_all`, `draw_all`, `cleanup_offscreen` and accessors.
- Implemented focused systems: `InputHandler` (`input_handler.h`/`.cpp`) for event handling and shooting, `UpdateSystem` (`update_system.h`/`.cpp`) for per-frame updates, `RenderSystem` (`render_system.h`/`.cpp`) for drawing based on `GameState`, and `CollisionSystem` (`collision_system.h`/`.cpp`) that splits collision logic into `handle_player_meteor`, `handle_player_bonus`, `handle_laser_meteor` and `cleanup_offscreen_entities`.
- Migrated meteor spawning to `EntityManager::spawn_meteors`, moved collision and cleanup flows into `CollisionSystem`, and updated the main loop so `Game::check_events`, `Game::update` and `Game::draw` delegate to the new systems.
- Applied const-correctness to public draw/get methods across `Player`, `Meteor`, `Laser`, `Bonus`, `Explosion`, `TextObj`, and `Splash` to support const rendering and safer interfaces.

### Testing
- No automated tests were executed for this change.
- Changes were built into the repository and committed, but no CI/build verification or runtime tests were run in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982f911b94c8327900854e46c0dd097)