### PR TITLE
Refactor game systems for readability and separation of concerns

### DIFF
--- a/collision_system.h
+++ b/collision_system.h
@@ -16,5 +16,9 @@ private:
 		GameState &game_state) const;
 	void handle_player_bonus(Player &player, EntityManager &entities) const;
 	void handle_laser_meteor(EntityManager &entities) const;
+	void handle_laser_meteor_collisions(EntityManager &entities) const;
+	void on_laser_hit_meteor(const Laser &laser,
+		Meteor &meteor,
+		EntityManager &entities) const;
 	void cleanup_offscreen_entities(EntityManager &entities) const;
 };

--- a/entity_manager.cpp
+++ b/entity_manager.cpp
@@ -1,6 +1,15 @@
 #include "entity_manager.h"
 #include "const.h"
 
+namespace {
+template <typename Container, typename Fn>
+void for_each_entity(Container &container, Fn &&fn) {
+	for (auto &entity : container) {
+		fn(entity);
+	}
+}
+} // namespace
+
 void EntityManager::spawn_meteors(size_t count) {
 	meteor_sprites.reserve(count);
 	for (size_t i = 0; i < count; i++) {
@@ -9,33 +18,17 @@ void EntityManager::spawn_meteors(size_t count) {
 }
 
 void EntityManager::update_all() {
-	for (auto &meteor : meteor_sprites) {
-		meteor->update();
-	}
-	for (auto &laser : laser_sprites) {
-		laser->update();
-	}
-	for (auto &bonus : bonus_sprites) {
-		bonus->update();
-	}
-	for (auto &exp : exp_sprites) {
-		exp->update();
-	}
+	for_each_entity(meteor_sprites, [](auto &meteor) { meteor->update(); });
+	for_each_entity(laser_sprites, [](auto &laser) { laser->update(); });
+	for_each_entity(bonus_sprites, [](auto &bonus) { bonus->update(); });
+	for_each_entity(exp_sprites, [](auto &exp) { exp->update(); });
 }
 
 void EntityManager::draw_all(sf::RenderWindow &window) const {
-	for (const auto &meteor : meteor_sprites) {
-		meteor->draw(window);
-	}
-	for (const auto &laser : laser_sprites) {
-		laser->draw(window);
-	}
-	for (const auto &bonus : bonus_sprites) {
-		bonus->draw(window);
-	}
-	for (const auto &exp : exp_sprites) {
-		exp->draw(window);
-	}
+	for_each_entity(meteor_sprites, [&window](const auto &meteor) { meteor->draw(window); });
+	for_each_entity(laser_sprites, [&window](const auto &laser) { laser->draw(window); });
+	for_each_entity(bonus_sprites, [&window](const auto &bonus) { bonus->draw(window); });
+	for_each_entity(exp_sprites, [&window](const auto &exp) { exp->draw(window); });
 }
 
 void EntityManager::cleanup_offscreen() {

--- a/input_handler.cpp
+++ b/input_handler.cpp
@@ -7,17 +7,32 @@ void InputHandler::handle_events(sf::RenderWindow &window,
 {
 	sf::Event event;
 	while (window.pollEvent(event)) {
-		if (event.type == sf::Event::Closed) {
+		switch (event.type) {
+		case sf::Event::Closed:
 			window.close();
-		} else if (event.type == sf::Event::MouseButtonPressed &&
-			event.mouseButton.button == sf::Mouse::Left) {
-			sf::Time elapsed = fire_clock.getElapsedTime();
-			if (elapsed.asMilliseconds() > 250) {
-				lasers.emplace_back(std::make_unique<Laser>(
-					player.getPosition().x + player.getWidth() / 2 - 5,
-					player.getPosition().y));
-				fire_clock.restart();
+			break;
+		case sf::Event::MouseButtonPressed:
+			if (event.mouseButton.button == sf::Mouse::Left) {
+				try_fire(player, lasers, fire_clock);
 			}
+			break;
+		default:
+			break;
 		}
 	}
+}
+
+void InputHandler::try_fire(Player &player,
+	std::list<std::unique_ptr<Laser>> &lasers,
+	sf::Clock &fire_clock) const
+{
+	sf::Time elapsed = fire_clock.getElapsedTime();
+	if (elapsed.asMilliseconds() <= 250) {
+		return;
+	}
+
+	lasers.emplace_back(std::make_unique<Laser>(
+		player.getPosition().x + player.getWidth() / 2 - 5,
+		player.getPosition().y));
+	fire_clock.restart();
 }

--- a/input_handler.h
+++ b/input_handler.h
@@ -12,4 +12,9 @@ public:
 		Player &player,
 		std::list<std::unique_ptr<Laser>> &lasers,
 		sf::Clock &fire_clock) const;
+
+private:
+	void try_fire(Player &player,
+		std::list<std::unique_ptr<Laser>> &lasers,
+		sf::Clock &fire_clock) const;
 };

--- a/meteor.cpp
+++ b/meteor.cpp
@@ -20,11 +20,7 @@ void Meteor::draw(sf::RenderWindow& window) const {
 }
 void Meteor::update() {
 	sprite.move(speedx, speedy);
-	if (sprite.getPosition().x < 0.f-getWidth() ||
-		sprite.getPosition().x > WINDOW_WIDTH ||
-		sprite.getPosition().y > WINDOW_HEIGHT
-		)
-	{
+	if (is_offscreen()) {
 		spawn();
 	}
 }
@@ -45,4 +41,10 @@ sf::Vector2f Meteor::getCenter() const {
 		sprite.getPosition().x + getWidth() / 2.0,
 		sprite.getPosition().y + getHeight() / 2.0
 	);
+}
+
+bool Meteor::is_offscreen() const {
+	return sprite.getPosition().x < 0.f - getWidth() ||
+		sprite.getPosition().x > WINDOW_WIDTH ||
+		sprite.getPosition().y > WINDOW_HEIGHT;
 }

--- a/meteor.h
+++ b/meteor.h
@@ -8,6 +8,8 @@ private:
 	float speedx;
 	float speedy;
 	static std::string meteor_file_names[];
+
+	bool is_offscreen() const;
 public:
 	Meteor();
 	void draw(sf::RenderWindow& window) const;

--- a/player.cpp
+++ b/player.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "const.h"
 #include "player.h"
 
@@ -11,19 +12,17 @@ void Player::draw(sf::RenderWindow& window) const {
 }
 void Player::update() {
 	float speedx = PLAYER_SPEEDX;
-	if (sf::Keyboard::isKeyPressed(sf::Keyboard::A) && 
-		sprite.getPosition().x > 0
-		)
-	{
-		sprite.move(-speedx, 0);
+	int direction = 0;
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::A)) {
+		direction -= 1;
 	}
-	else 
-		if (sf::Keyboard::isKeyPressed(sf::Keyboard::D) &&
-			sprite.getPosition().x < WINDOW_WIDTH - getWidth()
-			)
-		{
-			sprite.move(speedx, 0);
-		}
+	if (sf::Keyboard::isKeyPressed(sf::Keyboard::D)) {
+		direction += 1;
+	}
+
+	float next_x = sprite.getPosition().x + speedx * direction;
+	next_x = clamp_to_bounds(next_x);
+	sprite.setPosition(next_x, sprite.getPosition().y);
 }
 size_t Player::getWidth() const { return sprite.getLocalBounds().width; }
 size_t Player::getHeight() const { return sprite.getLocalBounds().height; }
@@ -32,3 +31,8 @@ sf::Vector2f Player::getPosition() const { return sprite.getPosition(); }
 void Player::reduceHp(float dmg) {	hp -= dmg; }
 bool Player::isDead() const { return hp < 0; }
 float Player::getHp() const { return hp; }
+
+float Player::clamp_to_bounds(float x) const {
+	float max_x = WINDOW_WIDTH - getWidth();
+	return std::clamp(x, 0.0f, max_x);
+}

--- a/player.h
+++ b/player.h
@@ -7,6 +7,8 @@ private:
 	sf::Sprite sprite;
 	sf::Texture texture;
 	float hp = PLAYER_HP;
+
+	float clamp_to_bounds(float x) const;
 public:
 	Player(float x, float y, std::string texture_file_name);
 	void draw(sf::RenderWindow& window) const;


### PR DESCRIPTION
### Motivation

- Simplify and separate responsibilities in collision handling to make detection and effects easier to extend and reason about.
- Reduce nested logic in bonus pickup and laser/meteor interactions for a clearer single-pass flow.
- Improve input and player code readability by reducing branching and isolating firing and bounds logic.
- Make Meteor offscreen checks and EntityManager iteration less repetitive to ease future changes and testing.

### Description

- Collision system: introduced a `LaserMeteorHit` struct and moved detection into `handle_laser_meteor_collisions` and effects into `on_laser_hit_meteor`, collecting hits first and applying effects afterward to separate detection from side effects and avoid nested action blocks; simplified `handle_player_bonus` to a single-pass erase-and-apply loop.
- Input handler: replaced chained `if/else` with a `switch` on `event.type` and added a private `try_fire` helper to centralize firing-rate checks and laser creation.
- Player: replaced cascade branching with a computed `direction` (-1/0/1) and added `clamp_to_bounds` to keep the player inside window limits. 
- Meteor: factored the offscreen predicate into `is_offscreen()` and used it in `update()` for clarity. 
- EntityManager: added a small `for_each_entity` template helper to remove duplicated loops in `update_all()` and `draw_all()` and replaced repeated loops with concise calls. 
- Updated corresponding headers (`collision_system.h`, `input_handler.h`, `player.h`, `meteor.h`) to expose the new helpers and predicates.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698333f04338832789dbf30e77307cde)